### PR TITLE
Replace bridged implementation with native implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,16 @@
 # Azure Identity Client
 
-This package is a very rough and simplified version of [Azure Identity](https://www.npmjs.com/package/@azure/identity) for Dart.
+This package is a simplified version of [Azure Identity](https://www.npmjs.com/package/@azure/identity) for Dart.
 
 Azure Identity provides token authentication mechanisms via Microsoft Entra ID identities. Since different authentication mechanisms are supported, it can be used to authenticate locally with a service deployed on Azure but can also be used to authenticate a Dart service with another service deployed on Azure.
 
-Microsoft offers implementations for different architectures, but no implementation exists for Dart. This code serves as an intermediate solution by providing a `BridgedDefaultAzureCredential()` implementation that exposes the same interface as `@azure/identity` for NodeJS but uses a pre-compiled NodeJS binary in the background to call the native `DefaultAzureCredential` implementation.
+Microsoft offers implementations for different architectures, but no implementation exists for Dart. This package aims to be a starting point for building a similar, feature equivalent solution.
 
-This method is not very efficient but straightforward. Contributions to implement various credential methods natively in Dart are welcome.
+A first version of this package used a work-around by using a NodeJS shim that called `DefaultAzureCredential()`. The NodeJS shim was cross-compiled to a binary and executed via shell environment. While this had the downside of not being publishable on (pub.dev)[https://pub.dev], it provided a very versatile initial solution. This version of the package is still available in the (bridged-implementation branch)[https://github.com/evoleen/azure_identity/tree/bridged-implementation].
 
-## Supported platforms
-
-As the package depends on a cross-compiled NodeJS executable, only platforms supported by the Bun runtime for cross-compilation are supported.
-
-- macOS
-- Linux
-
-Windows support is theoretically possible, but Bun crashes during installation. It is anticipated that this will be resolved with future Bun versions.
-
-## Integration
-
-The package ships with a compiled version of the `fetch_token` binary. If the final application is executed through the Dart interpreter, the package is able to automatically locate the platform-specific binary file and will execute it.
-
-If the final application is compiled to an executable, Dart is unable to package the `fetch_token` binary with the executable. The binary then needs to be added manually and path of the binary needs to be supplied to `BridgedDefaultAzureCredential()`.
+The current code is pure native Dart code and supports the following credentials:
+- Managed Identity 2017 API version
+- Managed Identity 2019 API version
+- Azure CLI credential
+- Chained credential
+- Default credential (a chained credential of Managed Identity 2017, Managed Identity 2019, Azure CLI)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Azure Identity provides token authentication mechanisms via Microsoft Entra ID i
 
 Microsoft offers implementations for different architectures, but no implementation exists for Dart. This package aims to be a starting point for building a similar, feature equivalent solution.
 
-A first version of this package used a work-around by using a NodeJS shim that called `DefaultAzureCredential()`. The NodeJS shim was cross-compiled to a binary and executed via shell environment. While this had the downside of not being publishable on (pub.dev)[https://pub.dev], it provided a very versatile initial solution. This version of the package is still available in the (bridged-implementation branch)[https://github.com/evoleen/azure_identity/tree/bridged-implementation].
+A first version of this package used a work-around by using a NodeJS shim that called `DefaultAzureCredential()`. The NodeJS shim was cross-compiled to a binary and executed via shell environment. While this had the downside of not being publishable on [pub.dev](https://pub.dev), it provided a very versatile initial solution. This version of the package is still available in the [bridged-implementation branch](https://github.com/evoleen/azure_identity/tree/bridged-implementation).
 
 The current code is pure native Dart code and supports the following credentials:
 - Managed Identity 2017 API version

--- a/example/azure_identity_example.dart
+++ b/example/azure_identity_example.dart
@@ -3,6 +3,7 @@ import 'package:talker/talker.dart';
 
 Future<void> main() async {
   final logger = Talker();
+
   // create instance of DefaultAzureCredential using the bridge binary
   final defaultAzureCredential = DefaultAzureCredential(
     logger: logger.info,

--- a/example/azure_identity_example.dart
+++ b/example/azure_identity_example.dart
@@ -2,15 +2,15 @@ import 'package:azure_identity/azure_identity.dart';
 import 'package:talker/talker.dart';
 
 Future<void> main() async {
+  final logger = Talker();
   // create instance of DefaultAzureCredential using the bridge binary
-  final bridgedDefaultAzureCredential =
-      await BridgedDefaultAzureCredential.create(
-    logger: Talker(),
+  final defaultAzureCredential = DefaultAzureCredential(
+    logger: logger.info,
   );
 
   // initialize credential manager
   final credentialManager = CredentialManager(
-    credential: bridgedDefaultAzureCredential,
+    credential: defaultAzureCredential,
     options: GetTokenOptions(
       scopes: [
         'https://kimdevworkspace-kim-data.fhir.azurehealthcareapis.com/'

--- a/lib/azure_identity.dart
+++ b/lib/azure_identity.dart
@@ -1,5 +1,10 @@
 library;
 
+export 'src/azure_cli_credential.dart';
 export 'src/bridged_default_azure_credential.dart';
+export 'src/chained_token_credential.dart';
 export 'src/credential_manager.dart';
+export 'src/default_azure_credential.dart';
+export 'src/managed_identity_credential_2017.dart';
+export 'src/managed_identity_credential_2019.dart';
 export 'src/token_credential.dart';

--- a/lib/src/azure_cli_credential.dart
+++ b/lib/src/azure_cli_credential.dart
@@ -27,6 +27,8 @@ class AzureCliCredential extends TokenCredential {
     );
 
     if (tokenProcessResult.exitCode != 0) {
+      logger?.call(
+          'AZ CLI returned error code ${tokenProcessResult.exitCode}, either AZ CLI is not installed or "az login" needs to be run.');
       return null;
     }
 

--- a/lib/src/azure_cli_credential.dart
+++ b/lib/src/azure_cli_credential.dart
@@ -7,6 +7,8 @@ import 'package:azure_identity/src/token_credential.dart';
 /// in development settings where the user authenticated through `az login`
 /// has an IAM privilege with the target service.
 class AzureCliCredential extends TokenCredential {
+  AzureCliCredential({super.logger});
+
   @override
   Future<AccessToken?> getToken({GetTokenOptions? options}) async {
     if (options == null || options.scopes.isEmpty) {

--- a/lib/src/azure_cli_credential.dart
+++ b/lib/src/azure_cli_credential.dart
@@ -32,7 +32,7 @@ class AzureCliCredential extends TokenCredential {
 
     return AccessToken(
       token: tokenOutput['accessToken'],
-      expiresOnTimestamp: int.parse(tokenOutput['expires_on']) * 1000,
+      expiresOnTimestamp: tokenOutput['expires_on'] * 1000,
     );
   }
 }

--- a/lib/src/azure_cli_credential.dart
+++ b/lib/src/azure_cli_credential.dart
@@ -6,7 +6,7 @@ import 'package:azure_identity/src/token_credential.dart';
 /// Attempts to acquire a token through running Azure CLI. Primarily useful
 /// in development settings where the user authenticated through `az login`
 /// has an IAM privilege with the target service.
-class AzureCliCredential implements TokenCredential {
+class AzureCliCredential extends TokenCredential {
   @override
   Future<AccessToken?> getToken({GetTokenOptions? options}) async {
     if (options == null || options.scopes.isEmpty) {

--- a/lib/src/azure_cli_credential.dart
+++ b/lib/src/azure_cli_credential.dart
@@ -1,0 +1,38 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:azure_identity/src/token_credential.dart';
+
+/// Attempts to acquire a token through running Azure CLI. Primarily useful
+/// in development settings where the user authenticated through `az login`
+/// has an IAM privilege with the target service.
+class AzureCliCredential implements TokenCredential {
+  @override
+  Future<AccessToken?> getToken({GetTokenOptions? options}) async {
+    if (options == null || options.scopes.isEmpty) {
+      return null;
+    }
+
+    final resource = options.scopes.first;
+
+    final tokenProcessResult = await Process.run(
+      'az',
+      [
+        'account',
+        'get-access-token',
+        '--resource=$resource',
+      ],
+    );
+
+    if (tokenProcessResult.exitCode != 0) {
+      return null;
+    }
+
+    final tokenOutput = jsonDecode(tokenProcessResult.stdout.toString());
+
+    return AccessToken(
+      token: tokenOutput['accessToken'],
+      expiresOnTimestamp: int.parse(tokenOutput['expires_on']) * 1000,
+    );
+  }
+}

--- a/lib/src/chained_token_credential.dart
+++ b/lib/src/chained_token_credential.dart
@@ -6,10 +6,10 @@ import 'package:azure_identity/azure_identity.dart';
 /// a unified implementation that works without changes in local development
 /// environments and in production environments, or if the authentication method
 /// is not fully known.
-class ChainedTokenCredential implements TokenCredential {
+class ChainedTokenCredential extends TokenCredential {
   final List<TokenCredential> credentials;
 
-  const ChainedTokenCredential({required this.credentials});
+  const ChainedTokenCredential({required this.credentials, super.logger});
 
   @override
   Future<AccessToken?> getToken({GetTokenOptions? options}) async {

--- a/lib/src/chained_token_credential.dart
+++ b/lib/src/chained_token_credential.dart
@@ -1,0 +1,26 @@
+import 'package:azure_identity/azure_identity.dart';
+
+/// Implements a credential that allows fetching a credential through a list
+/// of other credential providers. The class will try all providers in sequence
+/// and returns the first token it can acquire. This is useful to create
+/// a unified implementation that works without changes in local development
+/// environments and in production environments, or if the authentication method
+/// is not fully known.
+class ChainedTokenCredential implements TokenCredential {
+  final List<TokenCredential> credentials;
+
+  const ChainedTokenCredential({required this.credentials});
+
+  @override
+  Future<AccessToken?> getToken({GetTokenOptions? options}) async {
+    for (final credential in credentials) {
+      final accessToken = await credential.getToken(options: options);
+
+      if (accessToken != null) {
+        return accessToken;
+      }
+    }
+
+    return null;
+  }
+}

--- a/lib/src/default_azure_credential.dart
+++ b/lib/src/default_azure_credential.dart
@@ -1,0 +1,27 @@
+import 'package:azure_identity/src/chained_token_credential.dart';
+import 'package:azure_identity/src/managed_identity_credential_2017.dart';
+import 'package:azure_identity/src/managed_identity_credential_2019.dart';
+import 'package:azure_identity/src/token_credential.dart';
+
+/// Stripped down version of the Azure SDK's DefaultAzureCredential.
+/// Will attempt the following authentication methods in sequence:
+/// - Managed Identity 2019
+/// - Managed Identity 2017
+/// - Azure CLI
+/// The original Azure SDK offers a few more methods in DefaultAzureCredential
+/// which are not implemented in this package yet. However, the current methods
+/// should provide a single token source for 75% of all use cases in
+/// development and managed deployment scenarios.
+class DefaultAzureCredential implements TokenCredential {
+  final chainedTokenCredential = ChainedTokenCredential(
+    credentials: [
+      ManagedIdentityCredential2019(),
+      ManagedIdentityCredential2017(),
+    ],
+  );
+
+  @override
+  Future<AccessToken?> getToken({GetTokenOptions? options}) async {
+    return chainedTokenCredential.getToken(options: options);
+  }
+}

--- a/lib/src/default_azure_credential.dart
+++ b/lib/src/default_azure_credential.dart
@@ -12,7 +12,7 @@ import 'package:azure_identity/src/token_credential.dart';
 /// which are not implemented in this package yet. However, the current methods
 /// should provide a single token source for 75% of all use cases in
 /// development and managed deployment scenarios.
-class DefaultAzureCredential implements TokenCredential {
+class DefaultAzureCredential extends TokenCredential {
   final chainedTokenCredential = ChainedTokenCredential(
     credentials: [
       ManagedIdentityCredential2019(),

--- a/lib/src/default_azure_credential.dart
+++ b/lib/src/default_azure_credential.dart
@@ -1,7 +1,4 @@
-import 'package:azure_identity/src/chained_token_credential.dart';
-import 'package:azure_identity/src/managed_identity_credential_2017.dart';
-import 'package:azure_identity/src/managed_identity_credential_2019.dart';
-import 'package:azure_identity/src/token_credential.dart';
+import 'package:azure_identity/azure_identity.dart';
 
 /// Stripped down version of the Azure SDK's DefaultAzureCredential.
 /// Will attempt the following authentication methods in sequence:
@@ -17,8 +14,11 @@ class DefaultAzureCredential extends TokenCredential {
     credentials: [
       ManagedIdentityCredential2019(),
       ManagedIdentityCredential2017(),
+      AzureCliCredential(),
     ],
   );
+
+  DefaultAzureCredential({super.logger});
 
   @override
   Future<AccessToken?> getToken({GetTokenOptions? options}) async {

--- a/lib/src/default_azure_credential.dart
+++ b/lib/src/default_azure_credential.dart
@@ -10,15 +10,16 @@ import 'package:azure_identity/azure_identity.dart';
 /// should provide a single token source for 75% of all use cases in
 /// development and managed deployment scenarios.
 class DefaultAzureCredential extends TokenCredential {
-  final chainedTokenCredential = ChainedTokenCredential(
-    credentials: [
-      ManagedIdentityCredential2019(),
-      ManagedIdentityCredential2017(),
-      AzureCliCredential(),
-    ],
-  );
+  final ChainedTokenCredential chainedTokenCredential;
 
-  DefaultAzureCredential({super.logger});
+  DefaultAzureCredential({super.logger})
+      : chainedTokenCredential = ChainedTokenCredential(
+          credentials: [
+            ManagedIdentityCredential2019(logger: logger),
+            ManagedIdentityCredential2017(logger: logger),
+            AzureCliCredential(logger: logger),
+          ],
+        );
 
   @override
   Future<AccessToken?> getToken({GetTokenOptions? options}) async {

--- a/lib/src/managed_identity_credential_2017.dart
+++ b/lib/src/managed_identity_credential_2017.dart
@@ -19,6 +19,8 @@ class ManagedIdentityCredential2017 extends TokenCredential {
   @override
   Future<AccessToken?> getToken({GetTokenOptions? options}) async {
     if (options == null || options.scopes.isEmpty) {
+      logger
+          ?.call('Cannot fetch token for Managed Identity 2017 without scope.');
       return null;
     }
 
@@ -28,6 +30,8 @@ class ManagedIdentityCredential2017 extends TokenCredential {
     final msiSecret = Platform.environment['MSI_SECRET'] ?? '';
 
     if (msiEndpoint.isEmpty) {
+      logger?.call(
+          'Required environment variables for Managed Identity 2017 not found.');
       return null;
     }
 
@@ -43,6 +47,8 @@ class ManagedIdentityCredential2017 extends TokenCredential {
           }));
 
       if (tokenResponse.statusCode != 200) {
+        logger?.call(
+            'Fetch token request for Managed Identity 2017 resulted in HTTP status code ${tokenResponse.statusCode}');
         return null;
       }
 
@@ -52,7 +58,10 @@ class ManagedIdentityCredential2017 extends TokenCredential {
         token: tokenJson['access_token'],
         expiresOnTimestamp: int.parse(tokenJson['expires_on']) * 1000,
       );
-    } catch (_) {}
+    } catch (e) {
+      logger?.call(
+          'Fetch token request for Managed Identity 2017 caused exception: $e');
+    }
 
     return null;
   }

--- a/lib/src/managed_identity_credential_2017.dart
+++ b/lib/src/managed_identity_credential_2017.dart
@@ -6,7 +6,7 @@ import 'package:dio/dio.dart';
 /// Acquires a token through the Azure Managed Identity service. Requires the
 /// process to be executed inside Azure and with "managed identity" enabled.
 /// Uses the 2017 API.
-class ManagedIdentityCredential2017 implements TokenCredential {
+class ManagedIdentityCredential2017 extends TokenCredential {
   final Dio _dio;
 
   static const String apiVersion = '2017-09-01';

--- a/lib/src/managed_identity_credential_2017.dart
+++ b/lib/src/managed_identity_credential_2017.dart
@@ -14,7 +14,7 @@ class ManagedIdentityCredential2017 extends TokenCredential {
   /// Constructs a new managed identity credential. If [dio] is passed, will
   /// use the externally configured instance of the Dio client. Otherwise
   /// will instantiate an instance with default options.
-  ManagedIdentityCredential2017({Dio? dio}) : _dio = dio ?? Dio();
+  ManagedIdentityCredential2017({Dio? dio, super.logger}) : _dio = dio ?? Dio();
 
   @override
   Future<AccessToken?> getToken({GetTokenOptions? options}) async {

--- a/lib/src/managed_identity_credential_2017.dart
+++ b/lib/src/managed_identity_credential_2017.dart
@@ -1,0 +1,59 @@
+import 'dart:io';
+
+import 'package:azure_identity/azure_identity.dart';
+import 'package:dio/dio.dart';
+
+/// Acquires a token through the Azure Managed Identity service. Requires the
+/// process to be executed inside Azure and with "managed identity" enabled.
+/// Uses the 2017 API.
+class ManagedIdentityCredential2017 implements TokenCredential {
+  final Dio _dio;
+
+  static const String apiVersion = '2017-09-01';
+
+  /// Constructs a new managed identity credential. If [dio] is passed, will
+  /// use the externally configured instance of the Dio client. Otherwise
+  /// will instantiate an instance with default options.
+  ManagedIdentityCredential2017({Dio? dio}) : _dio = dio ?? Dio();
+
+  @override
+  Future<AccessToken?> getToken({GetTokenOptions? options}) async {
+    if (options == null || options.scopes.isEmpty) {
+      return null;
+    }
+
+    final resource = options.scopes[0];
+
+    final msiEndpoint = Platform.environment['MSI_ENDPOINT'] ?? '';
+    final msiSecret = Platform.environment['MSI_SECRET'] ?? '';
+
+    if (msiEndpoint.isEmpty) {
+      return null;
+    }
+
+    try {
+      final msiEndpointUri = Uri.parse(msiEndpoint);
+      final requestUri =
+          msiEndpointUri.resolve('?resource=$resource&api-version=$apiVersion');
+
+      final tokenResponse = await _dio.getUri(requestUri,
+          options: Options(headers: {
+            'Secret': msiSecret,
+            'Content-Type': 'application/json'
+          }));
+
+      if (tokenResponse.statusCode != 200) {
+        return null;
+      }
+
+      final tokenJson = tokenResponse.data;
+
+      return AccessToken(
+        token: tokenJson['access_token'],
+        expiresOnTimestamp: int.parse(tokenJson['expires_on']) * 1000,
+      );
+    } catch (_) {}
+
+    return null;
+  }
+}

--- a/lib/src/managed_identity_credential_2019.dart
+++ b/lib/src/managed_identity_credential_2019.dart
@@ -6,7 +6,7 @@ import 'package:dio/dio.dart';
 /// Acquires a token through the Azure Managed Identity service. Requires the
 /// process to be executed inside Azure and with "managed identity" enabled.
 /// Uses the 2019 API.
-class ManagedIdentityCredential2019 implements TokenCredential {
+class ManagedIdentityCredential2019 extends TokenCredential {
   final Dio _dio;
 
   static const String apiVersion = '2019-08-01';

--- a/lib/src/managed_identity_credential_2019.dart
+++ b/lib/src/managed_identity_credential_2019.dart
@@ -14,7 +14,7 @@ class ManagedIdentityCredential2019 extends TokenCredential {
   /// Constructs a new managed identity credential. If [dio] is passed, will
   /// use the externally configured instance of the Dio client. Otherwise
   /// will instantiate an instance with default options.
-  ManagedIdentityCredential2019({Dio? dio}) : _dio = dio ?? Dio();
+  ManagedIdentityCredential2019({Dio? dio, super.logger}) : _dio = dio ?? Dio();
 
   @override
   Future<AccessToken?> getToken({GetTokenOptions? options}) async {

--- a/lib/src/managed_identity_credential_2019.dart
+++ b/lib/src/managed_identity_credential_2019.dart
@@ -1,0 +1,64 @@
+import 'dart:io';
+
+import 'package:azure_identity/azure_identity.dart';
+import 'package:dio/dio.dart';
+
+/// Acquires a token through the Azure Managed Identity service. Requires the
+/// process to be executed inside Azure and with "managed identity" enabled.
+/// Uses the 2019 API.
+class ManagedIdentityCredential2019 implements TokenCredential {
+  final Dio _dio;
+
+  static const String apiVersion = '2019-08-01';
+
+  /// Constructs a new managed identity credential. If [dio] is passed, will
+  /// use the externally configured instance of the Dio client. Otherwise
+  /// will instantiate an instance with default options.
+  ManagedIdentityCredential2019({Dio? dio}) : _dio = dio ?? Dio();
+
+  @override
+  Future<AccessToken?> getToken({GetTokenOptions? options}) async {
+    if (options == null || options.scopes.isEmpty) {
+      return null;
+    }
+
+    final resource = options.scopes[0];
+
+    final identityEndpoint = Platform.environment['IDENTITY_ENDPOINT'] ?? '';
+    final identityHeader = Platform.environment['IDENTITY_HEADER'] ?? '';
+
+    if (identityEndpoint.isEmpty || identityHeader.isEmpty) {
+      return null;
+    }
+
+    try {
+      final identityEndpointUri = Uri.parse(identityEndpoint);
+      final requestUri = identityEndpointUri
+          .resolve('?resource=$resource&api-version=$apiVersion');
+
+      final tokenResponse = await _dio.getUri(
+        requestUri,
+        options: Options(
+          headers: {
+            'X-IDENTITY-HEADER': identityHeader,
+            'Content-Type': 'application/json',
+            'Accept': 'application/json',
+          },
+        ),
+      );
+
+      if (tokenResponse.statusCode != 200) {
+        return null;
+      }
+
+      final tokenJson = tokenResponse.data;
+
+      return AccessToken(
+        token: tokenJson['access_token'],
+        expiresOnTimestamp: int.parse(tokenJson['expires_on']) * 1000,
+      );
+    } catch (_) {}
+
+    return null;
+  }
+}

--- a/lib/src/managed_identity_credential_2019.dart
+++ b/lib/src/managed_identity_credential_2019.dart
@@ -19,6 +19,8 @@ class ManagedIdentityCredential2019 extends TokenCredential {
   @override
   Future<AccessToken?> getToken({GetTokenOptions? options}) async {
     if (options == null || options.scopes.isEmpty) {
+      logger
+          ?.call('Cannot fetch token for Managed Identity 2019 without scope.');
       return null;
     }
 
@@ -28,6 +30,8 @@ class ManagedIdentityCredential2019 extends TokenCredential {
     final identityHeader = Platform.environment['IDENTITY_HEADER'] ?? '';
 
     if (identityEndpoint.isEmpty || identityHeader.isEmpty) {
+      logger?.call(
+          'Required environment variables for Managed Identity 2019 not found.');
       return null;
     }
 
@@ -48,6 +52,8 @@ class ManagedIdentityCredential2019 extends TokenCredential {
       );
 
       if (tokenResponse.statusCode != 200) {
+        logger?.call(
+            'Fetch token request for Managed Identity 2019 resulted in HTTP status code ${tokenResponse.statusCode}');
         return null;
       }
 
@@ -57,7 +63,10 @@ class ManagedIdentityCredential2019 extends TokenCredential {
         token: tokenJson['access_token'],
         expiresOnTimestamp: int.parse(tokenJson['expires_on']) * 1000,
       );
-    } catch (_) {}
+    } catch (e) {
+      logger?.call(
+          'Fetch token request for Managed Identity 2019 caused exception: $e');
+    }
 
     return null;
   }

--- a/lib/src/token_credential.dart
+++ b/lib/src/token_credential.dart
@@ -1,5 +1,9 @@
 /// Represents a credential capable of providing an authentication token.
-abstract class TokenCredential {
+class TokenCredential {
+  final Function(String)? logger;
+
+  const TokenCredential({this.logger});
+
   /// Gets the token provided by this credential.
   ///
   /// This method is called automatically by Azure SDK client libraries. You may call this method
@@ -10,7 +14,9 @@ abstract class TokenCredential {
   ///             TokenCredential implementation might make.
   Future<AccessToken?> getToken({
     GetTokenOptions? options,
-  });
+  }) async {
+    throw Exception('Unimplemented');
+  }
 }
 
 /// Defines options for TokenCredential.getToken.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,6 +7,7 @@ environment:
 
 # Add regular dependencies here.
 dependencies:
+  dio: ^5.5.0+1
   jose: ^0.3.4
   talker: ^4.3.4
 # path: ^1.8.0


### PR DESCRIPTION
The publishing of this package on pub.dev was prevented by the mandatory inclusion of the compiled NodeJS binary that provided the "actual" implementation to fetch credentials.

Since this was not satisfactory, this pull request replaces the bridged implementation with a native implementation. The native implementation is partial in that it only implements Managed Identity 2017 & 2019 as well as Azure CLI credentials, but it fulfills the large majority of our use cases.

Once we publish this package to pub.dev, maybe there are contributors who are willing to contribute things like VSCode credentials and other providers.