### PR TITLE
Fix AzureCliCredential failing with scopes containing /.default

### DIFF
--- a/lib/src/azure_cli_credential.dart
+++ b/lib/src/azure_cli_credential.dart
@@ -39,13 +39,39 @@ class AzureCliCredential extends TokenCredential {
     return 'az';
   }
 
+  /// Determines whether the given [value] is a v2 OAuth scope or a v1
+  /// resource URI.
+  ///
+  /// A v2 scope contains a permission suffix appended to the base URI
+  /// (e.g. `api://my-app/.default`, `api://my-app/access`,
+  /// `https://graph.microsoft.com/User.Read`).
+  ///
+  /// A v1 resource is a bare URI with no meaningful path segments
+  /// (e.g. `api://my-app`, `https://management.azure.com/`).
+  ///
+  /// The distinction matters because Azure CLI's `az account get-access-token`
+  /// requires `--scope` for v2 scopes and `--resource` for v1 resources.
+  /// Passing a v2 scope to `--resource` fails because Azure CLI treats the
+  /// entire string (including the suffix) as a literal resource name.
+  static bool _isV2Scope(String value) {
+    final uri = Uri.tryParse(value);
+    if (uri == null) return false;
+
+    // A v2 scope has non-empty path segments (e.g. '.default' or 'access').
+    // A bare resource URI has no path or only a trailing slash (empty segment).
+    final hasPathSegments =
+        uri.pathSegments.any((segment) => segment.isNotEmpty);
+    return hasPathSegments;
+  }
+
   @override
   Future<AccessToken?> getToken({GetTokenOptions? options}) async {
     if (options == null || options.scopes.isEmpty) {
       return null;
     }
 
-    final resource = options.scopes.first;
+    final value = options.scopes.first;
+    final cliFlag = _isV2Scope(value) ? '--scope' : '--resource';
 
     try {
       final tokenProcessResult = await Process.run(
@@ -53,13 +79,15 @@ class AzureCliCredential extends TokenCredential {
         [
           'account',
           'get-access-token',
-          '--resource=$resource',
+          '$cliFlag=$value',
         ],
       );
 
       if (tokenProcessResult.exitCode != 0) {
         logger?.call(
-            'AZ CLI returned error code ${tokenProcessResult.exitCode}, either AZ CLI is not installed or "az login" needs to be run.');
+            'AZ CLI returned error code ${tokenProcessResult.exitCode}. '
+            'Command: $_azureCliPath account get-access-token $cliFlag=$value. '
+            'stderr: ${tokenProcessResult.stderr}');
         return null;
       }
 


### PR DESCRIPTION
## Summary

`AzureCliCredential` previously always used `--resource` when calling `az account get-access-token`. This fails when callers pass a v2 OAuth scope containing a `/.default` suffix (e.g. `api://my-app/.default`), because `--resource` treats the entire string as a literal resource name and Azure returns `AADSTS500011`.

The fix auto-detects whether the input is a **v2 scope** or a **v1 resource URI** and picks the correct CLI flag:

| Input format | Example | CLI flag used |
|---|---|---|
| v2 scope (has path segments) | `api://my-app/.default`, `api://my-app/access` | `--scope` |
| v1 resource (bare URI) | `api://my-app`, `https://management.azure.com/` | `--resource` |

Detection is based on whether the URI has non-empty path segments — v2 scopes always have a suffix (`.default`, `access`, `User.Read`, etc.), while v1 resource URIs are bare.

This is **fully backward compatible** — existing callers passing bare resource URIs continue to use `--resource` as before.

Also improves the error log message to include the actual command and stderr for easier debugging.

## Reproduction

```bash
# Fails — --resource treats /.default as part of the literal resource name
az account get-access-token --resource="api://my-app/.default"
# AADSTS500011: The resource principal named api://my-app/.default was not found...

# Works — --scope understands v2 format
az account get-access-token --scope="api://my-app/.default"

# Also works — --resource with bare URI (v1 style, existing behavior preserved)
az account get-access-token --resource="api://my-app"
```

## Test plan

- [x] Verified `--resource=api://.../.default` fails with exit code 1
- [x] Verified `--scope=api://.../.default` succeeds with exit code 0
- [x] Verified `--resource=api://...` (bare URI, no suffix) succeeds — backward compat confirmed
- [x] Run existing test suite